### PR TITLE
General ISA Improvement

### DIFF
--- a/disasm-py/src/lib.rs
+++ b/disasm-py/src/lib.rs
@@ -161,12 +161,20 @@ impl Ins {
         self.0.field_crm() as i64
     }
     #[getter]
-    fn ps_l(&self) -> i64 {
-        self.0.field_ps_l() as i64
+    fn ps_I(&self) -> i64 {
+        self.0.field_ps_I() as i64
+    }
+    #[getter]
+    fn ps_IX(&self) -> i64 {
+        self.0.field_ps_IX() as i64
     }
     #[getter]
     fn ps_W(&self) -> i64 {
         self.0.field_ps_W() as i64
+    }
+    #[getter]
+    fn ps_WX(&self) -> i64 {
+        self.0.field_ps_WX() as i64
     }
     #[getter]
     fn ps_NB(&self) -> i64 {

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -4204,21 +4204,21 @@ impl Ins {
             Opcode::Andis_ => String::new(),
             Opcode::B => {
                 let mut s = String::with_capacity(4);
-                if self.bit(30usize) {
-                    s.push('a');
-                }
                 if self.bit(31usize) {
                     s.push('l');
+                }
+                if self.bit(30usize) {
+                    s.push('a');
                 }
                 s
             }
             Opcode::Bc => {
                 let mut s = String::with_capacity(4);
-                if self.bit(30usize) {
-                    s.push('a');
-                }
                 if self.bit(31usize) {
                     s.push('l');
+                }
+                if self.bit(30usize) {
+                    s.push('a');
                 }
                 s
             }

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -1823,7 +1823,7 @@ impl Ins {
                 Field::crfS(CRField(((self.code >> 18u8) & 0x7) as _)),
             ],
             Opcode::Mcrxr => vec![Field::crfD(CRField(((self.code >> 23u8) & 0x7) as _))],
-            Opcode::Mfcr => vec![Field::crfD(CRField(((self.code >> 23u8) & 0x7) as _))],
+            Opcode::Mfcr => vec![Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _))],
             Opcode::Mffs => vec![Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _))],
             Opcode::Mfmsr => vec![Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _))],
             Opcode::Mfspr => vec![
@@ -2562,7 +2562,7 @@ impl Ins {
                 Field::crfD(CRField(((self.code >> 23u8) & 0x7) as _)),
                 Field::xer,
             ],
-            Opcode::Mfcr => vec![Field::crfD(CRField(((self.code >> 23u8) & 0x7) as _))],
+            Opcode::Mfcr => vec![Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _))],
             Opcode::Mffs => vec![Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _))],
             Opcode::Mfmsr => vec![Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _))],
             Opcode::Mfspr => vec![Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _))],

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -4807,7 +4807,13 @@ impl Ins {
             Opcode::Tlbsync => String::new(),
             Opcode::Tw => String::new(),
             Opcode::Twi => String::new(),
-            Opcode::Xor => String::new(),
+            Opcode::Xor => {
+                let mut s = String::with_capacity(4);
+                if self.bit(31usize) {
+                    s.push('.');
+                }
+                s
+            }
             Opcode::Xori => String::new(),
             Opcode::Xoris => String::new(),
         }

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -1157,8 +1157,10 @@ pub enum Field {
     crfD(CRField),
     crfS(CRField),
     crm(OpaqueU),
-    ps_l(GQR),
+    ps_I(GQR),
+    ps_IX(GQR),
     ps_W(OpaqueU),
+    ps_WX(OpaqueU),
     NB(OpaqueU),
     tbr(OpaqueU),
     mtfsf_FM(OpaqueU),
@@ -1201,8 +1203,10 @@ impl Field {
             Field::crfD(x) => Some(Argument::CRField(*x)),
             Field::crfS(x) => Some(Argument::CRField(*x)),
             Field::crm(x) => Some(Argument::OpaqueU(*x)),
-            Field::ps_l(x) => Some(Argument::GQR(*x)),
+            Field::ps_I(x) => Some(Argument::GQR(*x)),
+            Field::ps_IX(x) => Some(Argument::GQR(*x)),
             Field::ps_W(x) => Some(Argument::OpaqueU(*x)),
+            Field::ps_WX(x) => Some(Argument::OpaqueU(*x)),
             Field::NB(x) => Some(Argument::OpaqueU(*x)),
             Field::tbr(x) => Some(Argument::OpaqueU(*x)),
             Field::mtfsf_FM(x) => Some(Argument::OpaqueU(*x)),
@@ -1243,8 +1247,10 @@ impl Field {
             Field::crfD(_) => "crfD",
             Field::crfS(_) => "crfS",
             Field::crm(_) => "crm",
-            Field::ps_l(_) => "ps_l",
+            Field::ps_I(_) => "ps_I",
+            Field::ps_IX(_) => "ps_IX",
             Field::ps_W(_) => "ps_W",
+            Field::ps_WX(_) => "ps_WX",
             Field::NB(_) => "NB",
             Field::tbr(_) => "tbr",
             Field::mtfsf_FM(_) => "mtfsf_FM",
@@ -1931,7 +1937,7 @@ impl Ins {
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_I(GQR(((self.code >> 12u8) & 0x7) as _)),
             ],
             Opcode::PsqLu => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
@@ -1940,21 +1946,21 @@ impl Ins {
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_I(GQR(((self.code >> 12u8) & 0x7) as _)),
             ],
             Opcode::PsqLux => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::rB(GPR(((self.code >> 11u8) & 0x1f) as _)),
-                Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_WX(OpaqueU(((self.code >> 10u8) & 0x1) as _)),
+                Field::ps_IX(GQR(((self.code >> 7u8) & 0x7) as _)),
             ],
             Opcode::PsqLx => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::rB(GPR(((self.code >> 11u8) & 0x1f) as _)),
-                Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_WX(OpaqueU(((self.code >> 10u8) & 0x1) as _)),
+                Field::ps_IX(GQR(((self.code >> 7u8) & 0x7) as _)),
             ],
             Opcode::PsqSt => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
@@ -1963,7 +1969,7 @@ impl Ins {
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_I(GQR(((self.code >> 12u8) & 0x7) as _)),
             ],
             Opcode::PsqStu => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
@@ -1972,21 +1978,21 @@ impl Ins {
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_I(GQR(((self.code >> 12u8) & 0x7) as _)),
             ],
             Opcode::PsqStux => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::rB(GPR(((self.code >> 11u8) & 0x1f) as _)),
-                Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_WX(OpaqueU(((self.code >> 10u8) & 0x1) as _)),
+                Field::ps_IX(GQR(((self.code >> 7u8) & 0x7) as _)),
             ],
             Opcode::PsqStx => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::rB(GPR(((self.code >> 11u8) & 0x1f) as _)),
-                Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
-                Field::ps_l(GQR(((self.code >> 12u8) & 0x7) as _)),
+                Field::ps_WX(OpaqueU(((self.code >> 10u8) & 0x1) as _)),
+                Field::ps_IX(GQR(((self.code >> 7u8) & 0x7) as _)),
             ],
             Opcode::PsAbs => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
@@ -6050,12 +6056,20 @@ impl Ins {
         ((self.code >> 12u8) & 0xff) as _
     }
     #[inline(always)]
-    pub fn field_ps_l(&self) -> usize {
+    pub fn field_ps_I(&self) -> usize {
         ((self.code >> 12u8) & 0x7) as _
+    }
+    #[inline(always)]
+    pub fn field_ps_IX(&self) -> usize {
+        ((self.code >> 7u8) & 0x7) as _
     }
     #[inline(always)]
     pub fn field_ps_W(&self) -> usize {
         ((self.code >> 15u8) & 0x1) as _
+    }
+    #[inline(always)]
+    pub fn field_ps_WX(&self) -> usize {
+        ((self.code >> 10u8) & 0x1) as _
     }
     #[inline(always)]
     pub fn field_NB(&self) -> usize {

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -2189,8 +2189,8 @@ impl Ins {
                 Field::SH(OpaqueU(((self.code >> 11u8) & 0x1f) as _)),
             ],
             Opcode::Srw => vec![
-                Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
+                Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rB(GPR(((self.code >> 11u8) & 0x1f) as _)),
             ],
             Opcode::Stb => vec![

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -5843,7 +5843,7 @@ impl Ins {
                         args: vec![
                             Argument::GPR(GPR(((self.code >> 16u8) & 0x1f) as _)),
                             Argument::GPR(GPR(((self.code >> 21u8) & 0x1f) as _)),
-                            Argument::OpaqueU(OpaqueU(((self.code >> 1u8) & 0x1f) as _)),
+                            Argument::OpaqueU(OpaqueU(((self.code >> 11u8) & 0x1f) as _)),
                         ],
                         ins: self,
                     };

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -5708,17 +5708,6 @@ impl Ins {
                         ins: self,
                     };
                 }
-                if (((((self.code >> 11u8) & 0x3ff) & 0b11111_00000u32) >> 5u32)
-                    | ((((self.code >> 11u8) & 0x3ff) & 0b00000_11111u32) << 5u32))
-                    as u32
-                    == 571
-                {
-                    return SimplifiedIns {
-                        mnemonic: "mftdu",
-                        args: vec![Argument::GPR(GPR(((self.code >> 21u8) & 0x1f) as _))],
-                        ins: self,
-                    };
-                }
             }
             Opcode::Mtspr => {
                 if (((((self.code >> 11u8) & 0x3ff) & 0b11111_00000u32) >> 5u32)
@@ -5772,17 +5761,6 @@ impl Ins {
                 {
                     return SimplifiedIns {
                         mnemonic: "mtdbatu",
-                        args: vec![Argument::GPR(GPR(((self.code >> 21u8) & 0x1f) as _))],
-                        ins: self,
-                    };
-                }
-                if (((((self.code >> 11u8) & 0x3ff) & 0b11111_00000u32) >> 5u32)
-                    | ((((self.code >> 11u8) & 0x3ff) & 0b00000_11111u32) << 5u32))
-                    as u32
-                    == 571
-                {
-                    return SimplifiedIns {
-                        mnemonic: "mttdu",
                         args: vec![Argument::GPR(GPR(((self.code >> 21u8) & 0x1f) as _))],
                         ins: self,
                     };

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -1133,6 +1133,7 @@ pub enum Field {
     ps_offset(Offset),
     BO(OpaqueU),
     BI(OpaqueU),
+    BH(OpaqueU),
     BD(BranchDest),
     LI(BranchDest),
     SH(OpaqueU),
@@ -1176,6 +1177,7 @@ impl Field {
             Field::ps_offset(x) => Some(Argument::Offset(*x)),
             Field::BO(x) => Some(Argument::OpaqueU(*x)),
             Field::BI(x) => Some(Argument::OpaqueU(*x)),
+            Field::BH(x) => Some(Argument::OpaqueU(*x)),
             Field::BD(x) => Some(Argument::BranchDest(*x)),
             Field::LI(x) => Some(Argument::BranchDest(*x)),
             Field::SH(x) => Some(Argument::OpaqueU(*x)),
@@ -1217,6 +1219,7 @@ impl Field {
             Field::ps_offset(_) => "ps_offset",
             Field::BO(_) => "BO",
             Field::BI(_) => "BI",
+            Field::BH(_) => "BH",
             Field::BD(_) => "BD",
             Field::LI(_) => "LI",
             Field::SH(_) => "SH",
@@ -1342,10 +1345,12 @@ impl Ins {
             Opcode::Bcctr => vec![
                 Field::BO(OpaqueU(((self.code >> 21u8) & 0x1f) as _)),
                 Field::BI(OpaqueU(((self.code >> 16u8) & 0x1f) as _)),
+                Field::BH(OpaqueU(((self.code >> 11u8) & 0x3) as _)),
             ],
             Opcode::Bclr => vec![
                 Field::BO(OpaqueU(((self.code >> 21u8) & 0x1f) as _)),
                 Field::BI(OpaqueU(((self.code >> 16u8) & 0x1f) as _)),
+                Field::BH(OpaqueU(((self.code >> 11u8) & 0x3) as _)),
             ],
             Opcode::Cmp => vec![
                 Field::crfD(CRField(((self.code >> 23u8) & 0x7) as _)),
@@ -5946,6 +5951,10 @@ impl Ins {
     #[inline(always)]
     pub fn field_BI(&self) -> usize {
         ((self.code >> 16u8) & 0x1f) as _
+    }
+    #[inline(always)]
+    pub fn field_BH(&self) -> usize {
+        ((self.code >> 11u8) & 0x3) as _
     }
     #[inline(always)]
     pub fn field_BD(&self) -> isize {

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -2075,7 +2075,6 @@ impl Ins {
             ],
             Opcode::PsMr => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
-                Field::frA(FPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::frB(FPR(((self.code >> 11u8) & 0x1f) as _)),
             ],
             Opcode::PsMsub => vec![

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -1277,21 +1277,21 @@ impl Ins {
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::simm(Simm(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
             ],
             Opcode::Addic => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::simm(Simm(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
             ],
             Opcode::Addic_ => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::simm(Simm(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
             ],
             Opcode::Addis => vec![
@@ -1328,13 +1328,15 @@ impl Ins {
                 Field::uimm(Uimm((self.code & 0xffff) as _)),
             ],
             Opcode::B => vec![Field::LI(BranchDest(
-                (((((self.code >> 2u8) & 0xffffff) ^ 0x800000).wrapping_sub(0x800000)) << 2u8) as _,
+                ((((((self.code >> 2u8) & 0xffffff) ^ 0x800000).wrapping_sub(0x800000)) as i32)
+                    << 2u8) as _,
             ))],
             Opcode::Bc => vec![
                 Field::BO(OpaqueU(((self.code >> 21u8) & 0x1f) as _)),
                 Field::BI(OpaqueU(((self.code >> 16u8) & 0x1f) as _)),
                 Field::BD(BranchDest(
-                    (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8) as _,
+                    ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) as i32)
+                        << 2u8) as _,
                 )),
             ],
             Opcode::Bcctr => vec![
@@ -1354,7 +1356,7 @@ impl Ins {
                 Field::crfD(CRField(((self.code >> 23u8) & 0x7) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::simm(Simm(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
             ],
             Opcode::Cmpl => vec![
@@ -1621,14 +1623,14 @@ impl Ins {
             Opcode::Lbz => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Lbzu => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -1645,14 +1647,14 @@ impl Ins {
             Opcode::Lfd => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Lfdu => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -1669,14 +1671,14 @@ impl Ins {
             Opcode::Lfs => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Lfsu => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -1693,14 +1695,14 @@ impl Ins {
             Opcode::Lha => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Lhau => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -1722,14 +1724,14 @@ impl Ins {
             Opcode::Lhz => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Lhzu => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -1746,7 +1748,7 @@ impl Ins {
             Opcode::Lmw => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -1773,14 +1775,14 @@ impl Ins {
             Opcode::Lwz => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Lwzu => vec![
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -1875,7 +1877,7 @@ impl Ins {
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::simm(Simm(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
             ],
             Opcode::Mullw => vec![
@@ -1920,7 +1922,7 @@ impl Ins {
             Opcode::PsqL => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::ps_offset(Offset(
-                    (((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as _,
+                    ((((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
@@ -1929,7 +1931,7 @@ impl Ins {
             Opcode::PsqLu => vec![
                 Field::frD(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::ps_offset(Offset(
-                    (((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as _,
+                    ((((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
@@ -1952,7 +1954,7 @@ impl Ins {
             Opcode::PsqSt => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::ps_offset(Offset(
-                    (((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as _,
+                    ((((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
@@ -1961,7 +1963,7 @@ impl Ins {
             Opcode::PsqStu => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::ps_offset(Offset(
-                    (((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as _,
+                    ((((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::ps_W(OpaqueU(((self.code >> 15u8) & 0x1) as _)),
@@ -2176,14 +2178,14 @@ impl Ins {
             Opcode::Stb => vec![
                 Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Stbu => vec![
                 Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2200,14 +2202,14 @@ impl Ins {
             Opcode::Stfd => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Stfdu => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2229,14 +2231,14 @@ impl Ins {
             Opcode::Stfs => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
             Opcode::Stfsu => vec![
                 Field::frS(FPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2253,7 +2255,7 @@ impl Ins {
             Opcode::Sth => vec![
                 Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2265,7 +2267,7 @@ impl Ins {
             Opcode::Sthu => vec![
                 Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2282,7 +2284,7 @@ impl Ins {
             Opcode::Stmw => vec![
                 Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2299,7 +2301,7 @@ impl Ins {
             Opcode::Stw => vec![
                 Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2316,7 +2318,7 @@ impl Ins {
             Opcode::Stwu => vec![
                 Field::rS(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
             ],
@@ -2349,7 +2351,7 @@ impl Ins {
                 Field::rD(GPR(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::simm(Simm(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
             ],
             Opcode::Subfme => vec![
@@ -2372,7 +2374,7 @@ impl Ins {
                 Field::TO(OpaqueU(((self.code >> 21u8) & 0x1f) as _)),
                 Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 Field::simm(Simm(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 )),
             ],
             Opcode::Xor => vec![
@@ -3128,7 +3130,7 @@ impl Ins {
             }
             Opcode::Lbz => {
                 let mut uses = vec![Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 ))];
                 if ((self.code >> 16u8) & 0x1f) != 0 {
                     uses.push(Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)));
@@ -3138,7 +3140,7 @@ impl Ins {
             Opcode::Lbzu => {
                 let mut uses = vec![
                     Field::offset(Offset(
-                        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                     )),
                     Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 ];
@@ -3160,7 +3162,7 @@ impl Ins {
             }
             Opcode::Lfd => {
                 let mut uses = vec![Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 ))];
                 if ((self.code >> 16u8) & 0x1f) != 0 {
                     uses.push(Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)));
@@ -3170,7 +3172,7 @@ impl Ins {
             Opcode::Lfdu => {
                 let mut uses = vec![
                     Field::offset(Offset(
-                        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                     )),
                     Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 ];
@@ -3192,7 +3194,7 @@ impl Ins {
             }
             Opcode::Lfs => {
                 let mut uses = vec![Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 ))];
                 if ((self.code >> 16u8) & 0x1f) != 0 {
                     uses.push(Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)));
@@ -3202,7 +3204,7 @@ impl Ins {
             Opcode::Lfsu => {
                 let mut uses = vec![
                     Field::offset(Offset(
-                        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                     )),
                     Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 ];
@@ -3224,7 +3226,7 @@ impl Ins {
             }
             Opcode::Lha => {
                 let mut uses = vec![Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 ))];
                 if ((self.code >> 16u8) & 0x1f) != 0 {
                     uses.push(Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)));
@@ -3234,7 +3236,7 @@ impl Ins {
             Opcode::Lhau => {
                 let mut uses = vec![
                     Field::offset(Offset(
-                        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                     )),
                     Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 ];
@@ -3263,7 +3265,7 @@ impl Ins {
             }
             Opcode::Lhz => {
                 let mut uses = vec![Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 ))];
                 if ((self.code >> 16u8) & 0x1f) != 0 {
                     uses.push(Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)));
@@ -3273,7 +3275,7 @@ impl Ins {
             Opcode::Lhzu => {
                 let mut uses = vec![
                     Field::offset(Offset(
-                        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                     )),
                     Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 ];
@@ -3295,7 +3297,7 @@ impl Ins {
             }
             Opcode::Lmw => {
                 let mut uses = vec![Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 ))];
                 if ((self.code >> 16u8) & 0x1f) != 0 {
                     uses.push(Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)));
@@ -3332,7 +3334,7 @@ impl Ins {
             }
             Opcode::Lwz => {
                 let mut uses = vec![Field::offset(Offset(
-                    (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                    ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                 ))];
                 if ((self.code >> 16u8) & 0x1f) != 0 {
                     uses.push(Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)));
@@ -3342,7 +3344,7 @@ impl Ins {
             Opcode::Lwzu => {
                 let mut uses = vec![
                     Field::offset(Offset(
-                        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _,
                     )),
                     Field::rA(GPR(((self.code >> 16u8) & 0x1f) as _)),
                 ];
@@ -4963,7 +4965,8 @@ impl Ins {
                         args: vec![
                             Argument::GPR(GPR(((self.code >> 21u8) & 0x1f) as _)),
                             Argument::Simm(Simm(
-                                (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                                ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32)
+                                    as _,
                             )),
                         ],
                         ins: self,
@@ -4997,8 +5000,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "blt",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5010,7 +5014,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5024,8 +5029,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "ble",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5037,7 +5043,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5051,8 +5058,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "beq",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5064,7 +5072,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5078,8 +5087,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "bge",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5091,7 +5101,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5105,8 +5116,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "bgt",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5118,7 +5130,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5132,8 +5145,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "bne",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5145,7 +5159,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5159,8 +5174,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "bso",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5172,7 +5188,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5186,8 +5203,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "bns",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5199,7 +5217,8 @@ impl Ins {
                         args: vec![
                             Argument::CRField(CRField(((self.code >> 18u8) & 0x7) as _)),
                             Argument::BranchDest(BranchDest(
-                                (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                    as i32)
                                     << 2u8) as _,
                             )),
                         ],
@@ -5210,8 +5229,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "bdnz",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5220,8 +5240,9 @@ impl Ins {
                     return SimplifiedIns {
                         mnemonic: "bdz",
                         args: vec![Argument::BranchDest(BranchDest(
-                            (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8)
-                                as _,
+                            ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000))
+                                as i32)
+                                << 2u8) as _,
                         ))],
                         ins: self,
                     };
@@ -5552,7 +5573,8 @@ impl Ins {
                         args: vec![
                             Argument::GPR(GPR(((self.code >> 16u8) & 0x1f) as _)),
                             Argument::Simm(Simm(
-                                (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                                ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32)
+                                    as _,
                             )),
                         ],
                         ins: self,
@@ -5565,7 +5587,8 @@ impl Ins {
                             Argument::CRField(CRField(((self.code >> 23u8) & 0x7) as _)),
                             Argument::GPR(GPR(((self.code >> 16u8) & 0x1f) as _)),
                             Argument::Simm(Simm(
-                                (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                                ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32)
+                                    as _,
                             )),
                         ],
                         ins: self,
@@ -5872,7 +5895,8 @@ impl Ins {
                         args: vec![
                             Argument::GPR(GPR(((self.code >> 16u8) & 0x1f) as _)),
                             Argument::Simm(Simm(
-                                (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                                ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32)
+                                    as _,
                             )),
                         ],
                         ins: self,
@@ -5884,7 +5908,8 @@ impl Ins {
                         args: vec![
                             Argument::GPR(GPR(((self.code >> 16u8) & 0x1f) as _)),
                             Argument::Simm(Simm(
-                                (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _,
+                                ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32)
+                                    as _,
                             )),
                         ],
                         ins: self,
@@ -5900,7 +5925,7 @@ impl Ins {
 impl Ins {
     #[inline(always)]
     pub fn field_simm(&self) -> isize {
-        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _
+        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _
     }
     #[inline(always)]
     pub fn field_uimm(&self) -> usize {
@@ -5908,11 +5933,11 @@ impl Ins {
     }
     #[inline(always)]
     pub fn field_offset(&self) -> isize {
-        (((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as _
+        ((((self.code & 0xffff) ^ 0x8000).wrapping_sub(0x8000)) as i32) as _
     }
     #[inline(always)]
     pub fn field_ps_offset(&self) -> isize {
-        (((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as _
+        ((((self.code & 0xfff) ^ 0x800).wrapping_sub(0x800)) as i32) as _
     }
     #[inline(always)]
     pub fn field_BO(&self) -> usize {
@@ -5924,11 +5949,11 @@ impl Ins {
     }
     #[inline(always)]
     pub fn field_BD(&self) -> isize {
-        (((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) << 2u8) as _
+        ((((((self.code >> 2u8) & 0x3fff) ^ 0x2000).wrapping_sub(0x2000)) as i32) << 2u8) as _
     }
     #[inline(always)]
     pub fn field_LI(&self) -> isize {
-        (((((self.code >> 2u8) & 0xffffff) ^ 0x800000).wrapping_sub(0x800000)) << 2u8) as _
+        ((((((self.code >> 2u8) & 0xffffff) ^ 0x800000).wrapping_sub(0x800000)) as i32) << 2u8) as _
     }
     #[inline(always)]
     pub fn field_SH(&self) -> usize {

--- a/disasm/src/generated.rs
+++ b/disasm/src/generated.rs
@@ -4532,13 +4532,7 @@ impl Ins {
             Opcode::Mcrfs => String::new(),
             Opcode::Mcrxr => String::new(),
             Opcode::Mfcr => String::new(),
-            Opcode::Mffs => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
+            Opcode::Mffs => String::new(),
             Opcode::Mfmsr => String::new(),
             Opcode::Mfspr => String::new(),
             Opcode::Mfsr => String::new(),
@@ -4591,13 +4585,7 @@ impl Ins {
                 }
                 s
             }
-            Opcode::Mulli => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
+            Opcode::Mulli => String::new(),
             Opcode::Mullw => {
                 let mut s = String::with_capacity(4);
                 if self.bit(21usize) {
@@ -4656,185 +4644,35 @@ impl Ins {
             Opcode::PsqStu => String::new(),
             Opcode::PsqStux => String::new(),
             Opcode::PsqStx => String::new(),
-            Opcode::PsAbs => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsAdd => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
+            Opcode::PsAbs => String::new(),
+            Opcode::PsAdd => String::new(),
             Opcode::PsCmpo0 => String::new(),
             Opcode::PsCmpo1 => String::new(),
             Opcode::PsCmpu0 => String::new(),
             Opcode::PsCmpu1 => String::new(),
-            Opcode::PsDiv => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMadd => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMadds0 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMadds1 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMerge00 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMerge01 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMerge10 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMerge11 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMr => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMsub => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMul => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMuls0 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsMuls1 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsNabs => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsNeg => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsNmadd => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsNmsub => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsRes => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsRsqrte => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsSel => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsSub => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsSum0 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
-            Opcode::PsSum1 => {
-                let mut s = String::with_capacity(4);
-                if self.bit(31usize) {
-                    s.push('.');
-                }
-                s
-            }
+            Opcode::PsDiv => String::new(),
+            Opcode::PsMadd => String::new(),
+            Opcode::PsMadds0 => String::new(),
+            Opcode::PsMadds1 => String::new(),
+            Opcode::PsMerge00 => String::new(),
+            Opcode::PsMerge01 => String::new(),
+            Opcode::PsMerge10 => String::new(),
+            Opcode::PsMerge11 => String::new(),
+            Opcode::PsMr => String::new(),
+            Opcode::PsMsub => String::new(),
+            Opcode::PsMul => String::new(),
+            Opcode::PsMuls0 => String::new(),
+            Opcode::PsMuls1 => String::new(),
+            Opcode::PsNabs => String::new(),
+            Opcode::PsNeg => String::new(),
+            Opcode::PsNmadd => String::new(),
+            Opcode::PsNmsub => String::new(),
+            Opcode::PsRes => String::new(),
+            Opcode::PsRsqrte => String::new(),
+            Opcode::PsSel => String::new(),
+            Opcode::PsSub => String::new(),
+            Opcode::PsSum0 => String::new(),
+            Opcode::PsSum1 => String::new(),
             Opcode::Rfi => String::new(),
             Opcode::Rlwimi => {
                 let mut s = String::with_capacity(4);

--- a/disasm/tests/test_disasm.rs
+++ b/disasm/tests/test_disasm.rs
@@ -784,6 +784,9 @@ fn test_ins_rlwimi() {
 fn test_ins_rlwinm() {
     assert_asm!(0x54000423, "rlwinm. r0, r0, 0, 16, 17");
     assert_asm!(0x54000432, "rlwinm r0, r0, 0, 16, 25");
+
+    // mnemonics
+    assert_asm!(0x57E5103A, "slwi r5, r31, 2");
 }
 
 #[test]

--- a/disasm/tests/test_disasm.rs
+++ b/disasm/tests/test_disasm.rs
@@ -622,8 +622,8 @@ fn test_ins_psq_lx() {
             frD(FPR(0)),
             rA(GPR(0)),
             rB(GPR(0)),
-            ps_W(OpaqueU(0)),
-            ps_l(GQR(0))
+            ps_WX(OpaqueU(0)),
+            ps_IX(GQR(0))
         ]
     );
     assert_eq!(ins.defs(), vec![frD(FPR(0))]);

--- a/disasm/tests/test_disasm.rs
+++ b/disasm/tests/test_disasm.rs
@@ -959,6 +959,7 @@ fn test_ins_sync() {
 #[test]
 fn test_ins_xor() {
     assert_asm!(0x7C052A78, "xor r5, r0, r5");
+    assert_asm!(0x7D275279, "xor. r7, r9, r10");
 }
 
 #[test]

--- a/disasm/tests/test_disasm.rs
+++ b/disasm/tests/test_disasm.rs
@@ -816,6 +816,7 @@ fn test_ins_srawi() {
 #[test]
 fn test_ins_srw() {
     assert_asm!(0x7C001C30, "srw r0, r0, r3");
+    assert_asm!(0x7C600430, "srw r0, r3, r0");
 }
 
 #[test]

--- a/disasm/tests/test_disasm.rs
+++ b/disasm/tests/test_disasm.rs
@@ -483,7 +483,7 @@ fn test_ins_lwzx() {
 
 #[test]
 fn test_ins_mfcr() {
-    assert_asm!(0x7C000026, "mfcr cr0");
+    assert_asm!(0x7C000026, "mfcr r0");
 }
 
 #[test]

--- a/disasm/tests/test_disasm.rs
+++ b/disasm/tests/test_disasm.rs
@@ -710,6 +710,11 @@ fn test_ins_ps_merge11() {
 }
 
 #[test]
+fn test_ins_ps_mr() {
+    assert_asm!(0x10200090, "ps_mr f1, f0");
+}
+
+#[test]
 fn test_ins_ps_msub() {
     assert_asm!(0x10A53778, "ps_msub f5, f5, f29, f6");
 }

--- a/disasm/tests/test_disasm.rs
+++ b/disasm/tests/test_disasm.rs
@@ -94,6 +94,7 @@ fn test_ins_b() {
     assert_asm!(0x4823B4D9, "bl 0x23b4d8");
     assert_asm!(0x4BE03C99, "bl -0x1fc368");
     assert_asm!(0x4BDC1A59, "bl -0x23e5a8");
+    assert_asm!(0x48000063, "bla 0x60");
 }
 
 #[test]

--- a/genisa/src/main.rs
+++ b/genisa/src/main.rs
@@ -136,7 +136,7 @@ impl Field {
         if self.signed {
             let mask2 = 1u32 << (self.bits.0.len() - 1);
             let mask2 = LitInt::new(&format!("0x{:x}", mask2), Span::call_site());
-            val = quote!(((#val ^ #mask2).wrapping_sub(#mask2)))
+            val = quote!((((#val ^ #mask2).wrapping_sub(#mask2)) as i32))
         }
 
         let val_shift = self.shift_left;

--- a/isa.yaml
+++ b/isa.yaml
@@ -22,6 +22,9 @@ fields:
   - name: BI
     arg: OpaqueU
     bits: 11..16
+  - name: BH
+    arg: OpaqueU
+    bits: 19..21
   - name: BD
     arg: BranchDest
     bits: 16..30
@@ -289,7 +292,7 @@ opcodes:
     bitmask: 0xfc007ffe
     pattern: 0x4c000420
     modifiers: [ LK ]
-    args: [ BO, BI ]
+    args: [ BO, BI, BH ]
     uses: [ ctr ]
 
   - name: bclr
@@ -297,7 +300,7 @@ opcodes:
     bitmask: 0xfc007ffe
     pattern: 0x4c000020
     modifiers: [ LK ]
-    args: [ BO, BI ]
+    args: [ BO, BI, BH ]
     uses: [ lr ]
 
   - name: cmp

--- a/isa.yaml
+++ b/isa.yaml
@@ -287,14 +287,14 @@ opcodes:
     desc: Branch
     bitmask: 0xfc000000
     pattern: 0x48000000
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ LI ]
 
   - name: bc
     desc: Branch Conditional
     bitmask: 0xfc000000
     pattern: 0x40000000
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BO, BI, BD ]
 
   - name: bcctr
@@ -2164,105 +2164,105 @@ mnemonics:
   # bc branch always
   - name: b
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     condition: BO == 20 && BI == 0
   # bc branch if negative
   - name: blt
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 12 && BI & 0b11 == 0b00 && crfS == 0
   - name: blt
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 12 && BI & 0b11 == 0b00
   # bc branch if not positive
   - name: ble
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 4 && BI & 0b11 == 0b01 && crfS == 0
   - name: ble
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 4 && BI & 0b11 == 0b01
   # bc branch if zero
   - name: beq
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 12 && BI & 0b11 == 0b10 && crfS == 0
   - name: beq
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 12 && BI & 0b11 == 0b10
   # bc branch if not negative
   - name: bge
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 4 && BI & 0b11 == 0b00 && crfS == 0
   - name: bge
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 4 && BI & 0b11 == 0b00
   # bc branch if positive
   - name: bgt
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 12 && BI & 0b11 == 0b01 && crfS == 0
   - name: bgt
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 12 && BI & 0b11 == 0b01
   # bc branch if not zero
   - name: bne
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 4 && BI & 0b11 == 0b10 && crfS == 0
   - name: bne
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 4 && BI & 0b11 == 0b10
   # bc branch if summary overflow
   - name: bso
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 12 && BI & 0b11 == 0b11 && crfS == 0
   - name: bso
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 12 && BI & 0b11 == 0b11
   # bc branch if not summary overflow
   - name: bns
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 4 && BI & 0b11 == 0b11 && crfS == 0
   - name: bns
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ crfS, BD ]
     condition: BO == 4 && BI & 0b11 == 0b11
 
   - name: bdnz
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 16 && BI == 0
   - name: bdz
     opcode: bc
-    modifiers: [ AA, LK ]
+    modifiers: [ LK, AA ]
     args: [ BD ]
     condition: BO == 18 && BI == 0
   # TODO support conditional bd...

--- a/isa.yaml
+++ b/isa.yaml
@@ -1635,7 +1635,7 @@ opcodes:
     bitmask: 0xfc0007fe
     pattern: 0x7c000430
     modifiers: [ Rc ]
-    args: [ rS, rA, rB ]
+    args: [ rA, rS, rB ]
     defs: [ rA ]
     uses: [ rA, rB ]
 

--- a/isa.yaml
+++ b/isa.yaml
@@ -1063,8 +1063,8 @@ opcodes:
     desc: Move from Condition Register
     bitmask: 0xfc1fffff
     pattern: 0x7c000026
-    args: [ crfD ]
-    defs: [ crfD ]
+    args: [ rD ]
+    defs: [ rD ]
 
   - name: mffs
     desc: Move from FPSCR

--- a/isa.yaml
+++ b/isa.yaml
@@ -1070,7 +1070,6 @@ opcodes:
     desc: Move from FPSCR
     bitmask: 0xfc1ffffe
     pattern: 0xfc00048e
-    modifiers: [ Rc ]
     args: [ frD ]
     defs: [ frD ]
 
@@ -1199,7 +1198,6 @@ opcodes:
     desc: Multiply Low Immediate
     bitmask: 0xfc000000
     pattern: 0x1c000000
-    modifiers: [ Rc ]
     args: [ rD, rA, simm ]
     defs: [ rD ]
     uses: [ rA ]
@@ -1340,7 +1338,6 @@ opcodes:
     desc: Paired Single Absolute Value
     bitmask: 0xfc1f07fe
     pattern: 0x10000210
-    modifiers: [ Rc ]
     args: [ frD, frB ]
     defs: [ frD ]
     uses: [ frB ]
@@ -1349,7 +1346,6 @@ opcodes:
     desc: Paired Single Add
     bitmask: 0xfc0007fe
     pattern: 0x1000002a
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frA, frB ]
@@ -1390,7 +1386,6 @@ opcodes:
     desc: Paired Single Divide
     bitmask: 0xfc0007fe
     pattern: 0x10000024
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frA, frB ]
@@ -1399,7 +1394,6 @@ opcodes:
     desc: Paired Single Multiply-Add
     bitmask: 0xfc00003e
     pattern: 0x1000003a
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1408,7 +1402,6 @@ opcodes:
     desc: Paired Single Multiply-Add Scalar high
     bitmask: 0xfc00003e
     pattern: 0x1000001c
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1417,7 +1410,6 @@ opcodes:
     desc: Paired Single Multiply-Add Scalar low
     bitmask: 0xfc00003e
     pattern: 0x1000001e
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1426,7 +1418,6 @@ opcodes:
     desc: Paired Single MERGE high
     bitmask: 0xfc0007fe
     pattern: 0x10000420
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frA, frB ]
@@ -1435,7 +1426,6 @@ opcodes:
     desc: Paired Single MERGE direct
     bitmask: 0xfc0007fe
     pattern: 0x10000460
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frA, frB ]
@@ -1444,7 +1434,6 @@ opcodes:
     desc: Paired Single MERGE swapped
     bitmask: 0xfc0007fe
     pattern: 0x100004a0
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frA, frB ]
@@ -1453,7 +1442,6 @@ opcodes:
     desc: Paired Single MERGE low
     bitmask: 0xfc0007fe
     pattern: 0x100004e0
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frA, frB ]
@@ -1462,7 +1450,6 @@ opcodes:
     desc: Paired Single Move Register
     bitmask: 0xfc1f07fe
     pattern: 0x10000090
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frB ]
@@ -1471,7 +1458,6 @@ opcodes:
     desc: Paired Single Multiply-Subtract
     bitmask: 0xfc00003e
     pattern: 0x10000038
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1480,7 +1466,6 @@ opcodes:
     desc: Paired Single Multiply
     bitmask: 0xfc00f83e
     pattern: 0x10000032
-    modifiers: [ Rc ]
     args: [ frD, frA, frC ]
     defs: [ frD ]
     uses: [ frA, frC ]
@@ -1489,7 +1474,6 @@ opcodes:
     desc: Paired Single Multiply Scalar high
     bitmask: 0xfc00f83e
     pattern: 0x10000018
-    modifiers: [ Rc ]
     args: [ frD, frA, frC ]
     defs: [ frD ]
     uses: [ frA, frC ]
@@ -1498,7 +1482,6 @@ opcodes:
     desc: Paired Single Multiply Scalar low
     bitmask: 0xfc00f83e
     pattern: 0x1000001a
-    modifiers: [ Rc ]
     args: [ frD, frA, frC ]
     defs: [ frD ]
     uses: [ frA, frC ]
@@ -1507,7 +1490,6 @@ opcodes:
     desc: Paired Single Negative Absolute Value
     bitmask: 0xfc1f07fe
     pattern: 0x10000110
-    modifiers: [ Rc ]
     args: [ frD, frB ]
     defs: [ frD ]
     uses: [ frB ]
@@ -1516,7 +1498,6 @@ opcodes:
     desc: Paired Single Negate
     bitmask: 0xfc1f07fe
     pattern: 0x10000050
-    modifiers: [ Rc ]
     args: [ frD, frB ]
     defs: [ frD ]
     uses: [ frB ]
@@ -1525,7 +1506,6 @@ opcodes:
     desc: Paired Single Negative Multiply-Add
     bitmask: 0xfc00003e
     pattern: 0x1000003e
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1534,7 +1514,6 @@ opcodes:
     desc: Paired Single Negative Multiply-Subtract
     bitmask: 0xfc00003e
     pattern: 0x1000003c
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1543,7 +1522,6 @@ opcodes:
     desc: Paired Single Reciprocal Estimate
     bitmask: 0xfc1f07fe
     pattern: 0x10000030
-    modifiers: [ Rc ]
     args: [ frD, frB ]
     defs: [ frD ]
     uses: [ frB ]
@@ -1552,7 +1530,6 @@ opcodes:
     desc: Paired Single Reciprocal Square Root Estimate
     bitmask: 0xfc1f07fe
     pattern: 0x10000034
-    modifiers: [ Rc ]
     args: [ frD, frB ]
     defs: [ frD ]
     uses: [ frB ]
@@ -1561,7 +1538,6 @@ opcodes:
     desc: Paired Single Select
     bitmask: 0xfc00003e
     pattern: 0x1000002e
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1570,7 +1546,6 @@ opcodes:
     desc: Paired Single Subtract
     bitmask: 0xfc0007fe
     pattern: 0x10000028
-    modifiers: [ Rc ]
     args: [ frD, frA, frB ]
     defs: [ frD ]
     uses: [ frA, frB ]
@@ -1579,7 +1554,6 @@ opcodes:
     desc: Paired Single vector SUM high
     bitmask: 0xfc00003e
     pattern: 0x10000014
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]
@@ -1588,7 +1562,6 @@ opcodes:
     desc: Paired Single vector SUM low
     bitmask: 0xfc00003e
     pattern: 0x10000016
-    modifiers: [ Rc ]
     args: [ frD, frA, frC, frB ]
     defs: [ frD ]
     uses: [ frA, frC, frB ]

--- a/isa.yaml
+++ b/isa.yaml
@@ -1926,6 +1926,7 @@ opcodes:
     desc: XOR
     bitmask: 0xfc0007fe
     pattern: 0x7c000278
+    modifiers: [ Rc ]
     args: [ rA, rS, rB ]
     defs: [ rA ]
     uses: [ rS, rB ]

--- a/isa.yaml
+++ b/isa.yaml
@@ -2103,10 +2103,6 @@ mnemonics:
     opcode: mtspr
     args: [ rS ]
     condition: spr == 397
-  - name: mttdu
-    opcode: mtspr
-    args: [ rS ]
-    condition: spr == 571
 
   # Move from special-purpose register
   - name: mfxer
@@ -2129,10 +2125,6 @@ mnemonics:
     opcode: mfspr
     args: [ rD ]
     condition: spr == 397
-  - name: mftdu
-    opcode: mfspr
-    args: [ rD ]
-    condition: spr == 571
 
   # Branch Conditional
   # bc branch always

--- a/isa.yaml
+++ b/isa.yaml
@@ -112,12 +112,18 @@ fields:
     arg: OpaqueU
     bits: 12..20
   # Paired single fields
-  - name: ps_l
+  - name: ps_I
     arg: GQR
     bits: 17..20
+  - name: ps_IX
+    arg: GQR
+    bits: 22..25
   - name: ps_W
     arg: OpaqueU
     bits: 16..17
+  - name: ps_WX
+    arg: OpaqueU
+    bits: 21..22
   # Misc
   - name: NB
     arg: OpaqueU
@@ -1268,7 +1274,7 @@ opcodes:
     desc: Paired Single Quantized Load
     bitmask: 0xfc000000
     pattern: 0xe0000000
-    args: [ frD, ps_offset, rA, ps_W, ps_l ]
+    args: [ frD, ps_offset, rA, ps_W, ps_I ]
     defs: [ frD ]
     uses: [ rA.nz ]
 
@@ -1276,7 +1282,7 @@ opcodes:
     desc: Paired Single Quantized Load with Update
     bitmask: 0xfc000000
     pattern: 0xe4000000
-    args: [ frD, ps_offset, rA, ps_W, ps_l ]
+    args: [ frD, ps_offset, rA, ps_W, ps_I ]
     defs: [ frD, rA ]
     uses: [ rA ]
 
@@ -1284,7 +1290,7 @@ opcodes:
     desc: Paired Single Quantized Load with Update Indexed
     bitmask: 0xfc00007f
     pattern: 0x1000004c
-    args: [ frD, rA, rB, ps_W, ps_l ]
+    args: [ frD, rA, rB, ps_WX, ps_IX ]
     defs: [ frD, rA ]
     uses: [ rA, rB ]
 
@@ -1292,7 +1298,7 @@ opcodes:
     desc: Paired Single Quantized Load Indexed
     bitmask: 0xfc00007f
     pattern: 0x1000000c
-    args: [ frD, rA, rB, ps_W, ps_l ]
+    args: [ frD, rA, rB, ps_WX, ps_IX ]
     defs: [ frD ]
     uses: [ rA.nz, rB ]
 
@@ -1300,14 +1306,14 @@ opcodes:
     desc: Paired Single Quantized Store
     bitmask: 0xfc000000
     pattern: 0xf0000000
-    args: [ frS, ps_offset, rA, ps_W, ps_l ]
+    args: [ frS, ps_offset, rA, ps_W, ps_I ]
     uses: [ frS, rA.nz ]
 
   - name: psq_stu
     desc: Paired Single Quantized Store with Update
     bitmask: 0xfc000000
     pattern: 0xf4000000
-    args: [ frS, ps_offset, rA, ps_W, ps_l ]
+    args: [ frS, ps_offset, rA, ps_W, ps_I ]
     defs: [ rA ]
     uses: [ frS, rA ]
 
@@ -1315,7 +1321,7 @@ opcodes:
     desc: Paired Single Quantized Store with Update Indexed
     bitmask: 0xfc00007f
     pattern: 0x1000004e
-    args: [ frS, rA, rB, ps_W, ps_l ]
+    args: [ frS, rA, rB, ps_WX, ps_IX ]
     defs: [ rA ]
     uses: [ frS, rA, rB ]
 
@@ -1323,7 +1329,7 @@ opcodes:
     desc: Paired Single Quantized Store Indexed
     bitmask: 0xfc00007f
     pattern: 0x1000000e
-    args: [ frS, rA, rB, ps_W, ps_l ]
+    args: [ frS, rA, rB, ps_WX, ps_IX ]
     uses: [ frS, rA.nz, rB ]
 
   - name: ps_abs

--- a/isa.yaml
+++ b/isa.yaml
@@ -1450,7 +1450,7 @@ opcodes:
     desc: Paired Single Move Register
     bitmask: 0xfc1f07fe
     pattern: 0x10000090
-    args: [ frD, frA, frB ]
+    args: [ frD, frB ]
     defs: [ frD ]
     uses: [ frB ]
 

--- a/isa.yaml
+++ b/isa.yaml
@@ -1976,7 +1976,7 @@ mnemonics:
     condition: MB == 0 && ME == 31
   - name: slwi
     opcode: rlwinm
-    args: [ rA, rS, ME ]
+    args: [ rA, rS, SH ]
     condition: MB == 0 && 31 - SH == ME
   - name: srwi
     opcode: rlwinm

--- a/isa.yaml
+++ b/isa.yaml
@@ -145,6 +145,10 @@ fields:
     arg: OpaqueU
     desc: Bitset for tw and twi
     bits: 6..11
+  - name: L
+    arg: OpaqueU
+    desc: Bitset for cmp, cmpi, cmpl, cmpli
+    bits: 10..11
   - name: xer
   - name: ctr
   - name: lr
@@ -313,7 +317,7 @@ opcodes:
     desc: Compare
     bitmask: 0xfc4007ff
     pattern: 0x7c000000
-    args: [ crfD, rA, rB ]
+    args: [ crfD, L, rA, rB ]
     defs: [ crfD ]
     uses: [ rA, rB ]
 
@@ -321,7 +325,7 @@ opcodes:
     desc: Compare Immediate
     bitmask: 0xfc400000
     pattern: 0x2c000000
-    args: [ crfD, rA, simm ]
+    args: [ crfD, L, rA, simm ]
     defs: [ crfD ]
     uses: [ rA ]
 
@@ -329,7 +333,7 @@ opcodes:
     desc: Compare Logical
     bitmask: 0xfc4007ff
     pattern: 0x7c000040
-    args: [ crfD, rA, rB ]
+    args: [ crfD, L, rA, rB ]
     defs: [ crfD ]
     uses: [ rA, rB ]
 
@@ -337,7 +341,7 @@ opcodes:
     desc: Compare Logical Immediate
     bitmask: 0xfc400000
     pattern: 0x28000000
-    args: [ crfD, rA, uimm ]
+    args: [ crfD, L, rA, uimm ]
     defs: [ crfD ]
     uses: [ rA ]
 
@@ -2005,37 +2009,73 @@ mnemonics:
     args: [ rA, rS, MB ]
     condition: ME == 31 && 32 - MB == SH
 
-  # Compares
-  - name: cmpw
-    opcode: cmp
-    args: [ rA, rB ]
-    condition: crfD == 0
-  - name: cmpw
-    opcode: cmp
-    args: [ crfD, rA, rB ]
-  - name: cmplw
-    opcode: cmpl
-    args: [ rA, rB ]
-    condition: crfD == 0
-  - name: cmplw
-    opcode: cmpl
-    args: [ crfD, rA, rB ]
+  # Compares Word
   - name: cmpwi
     opcode: cmpi
     args: [ rA, simm ]
-    condition: crfD == 0
+    condition: crfD == 0 && L == 0
   - name: cmpwi
     opcode: cmpi
     args: [ crfD, rA, simm ]
-    condition: crfD == 0
+    condition: L == 0
+  - name: cmpw
+    opcode: cmp
+    args: [ rA, rB ]
+    condition: crfD == 0 && L == 0
+  - name: cmpw
+    opcode: cmp
+    args: [ crfD, rA, rB ]
+    condition: L == 0
   - name: cmplwi
     opcode: cmpli
     args: [ rA, uimm ]
-    condition: crfD == 0
+    condition: crfD == 0 && L == 0
   - name: cmplwi
     opcode: cmpli
     args: [ crfD, rA, uimm ]
-    condition: crfD == 0
+    condition: L == 0
+  - name: cmplw
+    opcode: cmpl
+    args: [ rA, rB ]
+    condition: crfD == 0 && L == 0
+  - name: cmplw
+    opcode: cmpl
+    args: [ crfD, rA, rB ]
+    condition: L == 0
+
+  # Compares Doubleword
+  - name: cmpdi
+    opcode: cmpi
+    args: [ rA, simm ]
+    condition: crfD == 0 && L == 1
+  - name: cmpdi
+    opcode: cmpi
+    args: [ crfD, rA, simm ]
+    condition: L == 1
+  - name: cmpd
+    opcode: cmp
+    args: [ rA, rB ]
+    condition: crfD == 0 && L == 1
+  - name: cmpd
+    opcode: cmp
+    args: [ crfD, rA, rB ]
+    condition: L == 1
+  - name: cmpldi
+    opcode: cmpli
+    args: [ rA, uimm ]
+    condition: crfD == 0 && L == 1
+  - name: cmpldi
+    opcode: cmpli
+    args: [ crfD, rA, uimm ]
+    condition: L == 1
+  - name: cmpld
+    opcode: cmpl
+    args: [ rA, rB ]
+    condition: crfD == 0 && L == 1
+  - name: cmpld
+    opcode: cmpl
+    args: [ crfD, rA, rB ]
+    condition: L == 1
 
   # Condition Register Logical
   - name: crset


### PR DESCRIPTION
While porting `doldisasm.py` from python to rust ([dadosod](https://github.com/InusualZ/dadosod)), I decided to use this library to replace `capstone`. But, while I was testing his output I came across a couple of instruction that were mishandled. So, I fix them :)

All commits are atomic, you should be able to review them, commit by commit. All changes in instruction mnemonics were tested by [Dolphin](github.com/Dolphin-emu/dolphin)'s assembly view and CodeWarrior/Metrowerks assembler acceptance of said mnemonics.

Thanks you, for this wonderful library.